### PR TITLE
feat(filecoin): access tiers and agent-first structure for community data package

### DIFF
--- a/community/filecoin/skills.md
+++ b/community/filecoin/skills.md
@@ -4,21 +4,18 @@ This is the entry point for Filecoin ecosystem analysis: public goods funding, d
 
 ## Access tiers
 
-Data access depends on the user's API key scope. Default to COMMUNITY unless the user explicitly requests tables from a deeper layer or states they have org-level access.
+Data access depends on the user's role in the OSO platform. Default to COMMUNITY unless the user explicitly requests tables from a deeper layer or states they have org-level access.
 
 ```
-COMMUNITY (any Filecoin-scoped API key):
+COMMUNITY (any OSO user who has subscribed to the filecoin.filpgf_public.* datasets):
   filecoin.filpgf_public.*    — mart layer, pre-joined analysis views
   oso.*                        — public OSO data (projects, metrics, events)
 
-FILECOIN_ORG (Filecoin Foundation + OSO team):
+FILECOIN (any OSO user who is a member of the `filecoin` org space on OSO):
   filecoin.*                   — all tables: staging, entities, events, metrics, ROI, raw ingested data
-
-OSO_INTERNAL (OSO team only):
-  Model source code, pipeline configuration, private notebooks
 ```
 
-When generating queries, use `filecoin.filpgf_public.*` and `oso.*` tables. Only use deeper layers (staging, entities, events, metrics, roi) if the user has FILECOIN_ORG access and the mart layer cannot answer the question.
+When generating queries, use `filecoin.filpgf_public.*` and `oso.*` tables. Only use deeper layers (staging, entities, events, metrics, roi) if the user has FILECOIN access and the mart layer cannot answer the question.
 
 ## Resources
 
@@ -63,7 +60,7 @@ Use Trino SQL:
 ## Schema overview
 
 ```
-FILECOIN_ORG layer              Public layer
+FILECOIN layer              Public layer
 ───────────────────             ────────────
 filecoin.data_portal.*          oso.projects_v1
 filecoin.gsheets.*              oso.artifacts_by_project_v1
@@ -232,7 +229,7 @@ FROM filecoin.filpgf_public.projects_to_projects
 WHERE oso_project_slug = 'secured-finance'
 ```
 
-2. For real-time milestone data, use the Karma GAP API directly — see [guides/karma-api.md](guides/karma-api.md). No API key required. For warehouse-based milestone queries, see [FILECOIN_ORG: Karma milestones](#filecoin_org-karma-milestones-workflow) below.
+2. For real-time milestone data, use the Karma GAP API directly — see [guides/karma-api.md](guides/karma-api.md). No API key required. For warehouse-based milestone queries, see [FILECOIN: Karma milestones](#filecoin-karma-milestones-workflow) below.
 
 3. Pull snapshot metrics from the mart layer:
 
@@ -280,11 +277,11 @@ INNER JOIN oso.projects_v1 AS op
 
 ---
 
-## FILECOIN_ORG tables
+## FILECOIN tables
 
-Everything below requires FILECOIN_ORG access (full `filecoin.*` namespace). Do not use these tables unless the user has confirmed org-level access or explicitly requested tables from these schemas.
+Everything below requires FILECOIN access (full `filecoin.*` namespace). Do not use these tables unless the user has confirmed org-level access or explicitly requested tables from these schemas.
 
-### FILECOIN_ORG: Karma milestones workflow
+### FILECOIN: Karma milestones workflow
 
 For milestone data via the warehouse (rather than the Karma GAP API):
 
@@ -316,7 +313,7 @@ ORDER BY pod_slug, criticality, member_slug
 
 Pod grants map Karma slugs to pod slugs: `foc-filecoin-onachain-cloud` -> `foc`, `large-data-onboarding-pod-ldo-pod` -> `ldo`, `web2-object-storage-pod` -> `web2`.
 
-### FILECOIN_ORG: Full table inventory
+### FILECOIN: Full table inventory
 
 #### Ingested datasets (filecoin.data_portal.*)
 

--- a/community/filecoin/skills.md
+++ b/community/filecoin/skills.md
@@ -1,6 +1,6 @@
-# Filecoin PGF & ecosystem data
+# OSO agent guide — Filecoin PGF & ecosystem data
 
-This is the entry point for Filecoin ecosystem analysis: public goods funding, developer activity, onchain metrics, and network health. All data is queryable via Trino SQL through the OSO data warehouse.
+You are a data analyst with access to the OSO data warehouse. This document is the single entry point for **Filecoin ecosystem analysis** — public goods funding, developer activity, onchain metrics, and network health. All data is queryable via Trino SQL.
 
 ## Access tiers
 
@@ -25,6 +25,45 @@ When generating queries, use `filecoin.filpgf_public.*` and `oso.*` tables. Only
 - OSS Directory: https://github.com/opensource-observer/oss-directory — canonical source for project slugs, repos, and onchain artifacts
 - Karma GAP API: see [guides/karma-api.md](guides/karma-api.md) — direct API access to real-time milestone and grant data (no API key needed)
 - Metric selection framework: see [guides/propgf-metric-selection.md](guides/propgf-metric-selection.md) — how metrics map to KPIs, entity types, and attribution claims
+
+---
+
+## What can I ask?
+
+**Funding & ROI**
+- How much total funding has project X received (public + private)?
+- Which projects got the most ProPGF / RetroPGF / Impact Grant funding?
+- What's the funding-to-developer ratio across projects?
+- Which programs are deploying the most capital?
+
+**Developer activity**
+- How many active developers does project X have? Is that growing or shrinking?
+- Which projects have the most commit activity? The most PR activity?
+- Are developers sticking around or churning?
+
+**Onchain impact**
+- How much data has project X onboarded to Filecoin?
+- Which onramps are growing fastest?
+- What share of network onboarding does project X account for?
+- How much block reward revenue flows through a project's storage providers?
+
+**Dependencies & downstream impact**
+- Which infrastructure projects have the most downstream dependents?
+- If project X disappeared, how much onchain activity would be affected?
+- What do teams say they depend on (from the dependency survey)?
+
+**Milestones & progress (Karma)**
+- What milestones has project X committed to?
+- Which projects have completed milestones? Which are overdue?
+- Show me the Karma profile for project X alongside its actual metrics.
+
+**Network health**
+- What's the current network power, daily onboarding, and FIL price?
+- How has protocol revenue trended over the past quarter?
+
+**Pod-level analysis**
+- How are the FOC / LDO / Web2 pods performing collectively?
+- Which pod has the most active developers? The most data onboarded?
 
 ---
 

--- a/community/filecoin/skills.md
+++ b/community/filecoin/skills.md
@@ -1,59 +1,41 @@
-# OSO agent guide — Filecoin PGF & ecosystem data
+# Filecoin PGF & ecosystem data
 
-You are a data analyst with access to the OSO data warehouse. This document is the single entry point for **Filecoin ecosystem analysis** — public goods funding, developer activity, onchain metrics, and network health.
+This is the entry point for Filecoin ecosystem analysis: public goods funding, developer activity, onchain metrics, and network health. All data is queryable via Trino SQL through the OSO data warehouse.
 
-- **Live dashboard:** [oso.xyz/filecoin/Public-Goods-Funding](https://www.oso.xyz/filecoin/Public-Goods-Funding)
-- **Public repo:** [github.com/opensource-observer/insights](https://github.com/opensource-observer/insights)
-- **Dependency survey:** [dependency-survey.pages.dev](https://dependency-survey.pages.dev)
-- **OSS Directory:** [github.com/opensource-observer/oss-directory](https://github.com/opensource-observer/oss-directory) — canonical source for project slugs, repos, and onchain artifacts. To add or update a project, submit a PR to the [data/projects/](https://github.com/opensource-observer/oss-directory/tree/main/data/projects) directory.
-- **Karma GAP API:** See [guides/karma-api.md](guides/karma-api.md) for direct API access to real-time milestone and grant data (no API key needed).
-- **Metric Selection Framework:** See [guides/propgf-metric-selection.md](guides/propgf-metric-selection.md) for how metrics map to KPIs, entity types, and direct/indirect attribution claims.
+## Access tiers
 
----
+Data access depends on the user's API key scope. Default to COMMUNITY unless the user explicitly requests tables from a deeper layer or states they have org-level access.
 
-## What can I ask?
+```
+COMMUNITY (any Filecoin-scoped API key):
+  filecoin.filpgf_public.*    — mart layer, pre-joined analysis views
+  oso.*                        — public OSO data (projects, metrics, events)
 
-This dataset answers questions like:
+FILECOIN_ORG (Filecoin Foundation + OSO team):
+  filecoin.*                   — all tables: staging, entities, events, metrics, ROI, raw ingested data
 
-**Funding & ROI**
-- How much total funding has project X received (public + private)?
-- Which projects got the most ProPGF / RetroPGF / Impact Grant funding?
-- What's the funding-to-developer ratio across projects?
-- Which programs are deploying the most capital?
+OSO_INTERNAL (OSO team only):
+  Model source code, pipeline configuration, private notebooks
+```
 
-**Developer activity**
-- How many active developers does project X have? Is that growing or shrinking?
-- Which projects have the most commit activity? The most PR activity?
-- Are developers sticking around or churning?
+When generating queries, use `filecoin.filpgf_public.*` and `oso.*` tables. Only use deeper layers (staging, entities, events, metrics, roi) if the user has FILECOIN_ORG access and the mart layer cannot answer the question.
 
-**Onchain impact**
-- How much data has project X onboarded to Filecoin?
-- Which onramps are growing fastest?
-- What share of network onboarding does project X account for?
-- How much block reward revenue flows through a project's storage providers?
+## Resources
 
-**Dependencies & downstream impact**
-- Which infrastructure projects have the most downstream dependents?
-- If project X disappeared, how much onchain activity would be affected?
-- What do teams say they depend on (from the dependency survey)?
-
-**Milestones & progress (Karma)**
-- What milestones has project X committed to?
-- Which projects have completed milestones? Which are overdue?
-- Show me the Karma profile for project X alongside its actual metrics.
-
-**Network health**
-- What's the current network power, daily onboarding, and FIL price?
-- How has protocol revenue trended over the past quarter?
+- Live dashboard: https://www.oso.xyz/filecoin/Public-Goods-Funding
+- Public repo: https://github.com/opensource-observer/insights
+- Dependency survey: https://dependency-survey.pages.dev
+- OSS Directory: https://github.com/opensource-observer/oss-directory — canonical source for project slugs, repos, and onchain artifacts
+- Karma GAP API: see [guides/karma-api.md](guides/karma-api.md) — direct API access to real-time milestone and grant data (no API key needed)
+- Metric selection framework: see [guides/propgf-metric-selection.md](guides/propgf-metric-selection.md) — how metrics map to KPIs, entity types, and attribution claims
 
 ---
 
 ## Connection
 
-### If you're using OSO Chat or a notebook on oso.xyz
-The connection is automatic — just ask your question or write SQL directly.
+On OSO Chat or an oso.xyz notebook, the connection is automatic.
 
-### If you're using pyoso locally
+For local use with pyoso:
 
 ```bash
 uv add pyoso  # or: pip install pyoso
@@ -62,24 +44,15 @@ export OSO_API_KEY=<your_key>
 
 ```python
 from pyoso import Client
-client = Client()  # reads OSO_API_KEY from environment
+client = Client()
 df = client.to_pandas("SELECT * FROM filecoin.filpgf_public.projects LIMIT 10")
 ```
 
-### Getting an API key
-
-1. Sign up at [oso.xyz/start](https://www.oso.xyz/start)
-2. Go to **Settings → API Keys** in the OSO app
-3. Create a key scoped to the **Filecoin** organization
-
-**Important:** Filecoin data lives under the `filecoin.*` namespace, which requires a Filecoin-scoped API key. The default `oso.*` namespace is publicly accessible, but `filecoin.*` tables are customer-scoped.
-
----
+API key setup: sign up at https://www.oso.xyz/start, go to Settings > API Keys, create a key scoped to the Filecoin organization. The `oso.*` namespace is publicly accessible; `filecoin.*` tables require a Filecoin-scoped key.
 
 ## SQL dialect
 
-Use **Trino SQL**:
-
+Use Trino SQL:
 - `CAST(x AS VARCHAR)` not `SAFE_CAST`
 - `DATE_TRUNC('month', dt)` not `DATE_TRUNC(dt, MONTH)`
 - `COALESCE` not `IFNULL`
@@ -89,314 +62,85 @@ Use **Trino SQL**:
 
 ## Schema overview
 
-The Filecoin org has data organized in a layered DAG. A Filecoin-scoped API key gives access to all layers:
-
 ```
-Ingested Data                    OSO Public Data
-─────────────                    ───────────────
-filecoin.data_portal.*           oso.oss_directory.*
-filecoin.gsheets.*               oso.int_events__github_unified
-filecoin.karma.*
-filecoin.datacapstats.*
-filecoin.onramp_dependency_scores.*
-filecoin.token_prices.*
+FILECOIN_ORG layer              Public layer
+───────────────────             ────────────
+filecoin.data_portal.*          oso.projects_v1
+filecoin.gsheets.*              oso.artifacts_by_project_v1
+filecoin.karma.*                oso.timeseries_metrics_by_project_v0
+filecoin.datacapstats.*         oso.int_events__github_unified
+filecoin.token_prices.*         (etc.)
 filecoin.karma_milestones.*
 filecoin.attribution_registry.*
-
-        ↓                                ↓
-
-filecoin.staging_external.*      filecoin.staging_oso.*
-        ↓                                ↓
-              filecoin.entities.*
-                     ↓
-              filecoin.events.*
-                     ↓
-              filecoin.metrics.*
-                     ↓
-        filecoin.filpgf_public.*  ←  filecoin.roi.*
+filecoin.onramp_dependency_scores.*
+        |                               |
+        v                               v
+filecoin.staging_external.*     filecoin.staging_oso.*
+        |                               |
+        +-------> filecoin.entities.* <--+
+                         |
+                  filecoin.events.*
+                         |
+                  filecoin.metrics.*
+                         |
+             filecoin.filpgf_public.*  <-- filecoin.roi.*
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+             COMMUNITY layer — default for all queries
 ```
-
-For most analysis, start with `filecoin.filpgf_public.*` (the mart layer). Go deeper into staging/entities/metrics when you need custom joins or granularity the marts don't expose.
 
 ---
 
-## Discovering metrics
+## COMMUNITY tables: filecoin.filpgf_public.*
 
-Rather than listing every metric here (they evolve), query the catalog directly:
+All tables use `oso_project_slug` as the universal join key. Slugs come from OSS Directory — each project's YAML filename (minus `.yaml`) is its slug.
+
+### Mart table reference
+
+| Table | Grain | Description |
+|-------|-------|-------------|
+| `projects` | project | Tracked projects with display names and metadata |
+| `artifacts_by_project` | (project, artifact) | Repos, onchain client IDs, and grant applications per project |
+| `projects_to_projects` | (project, source, name) | Cross-system identity bridges: OSSD, Karma, Drips, Data Portal |
+| `metric_catalog` | metric | Metric definitions, units, categories, and descriptions |
+| `timeseries_metrics_by_project` | (project, date, interval, metric) | Any metric trended over time for a project |
+| `key_metrics_by_project` | (project, metric) | Latest snapshot + lifetime totals per project |
+| `timeseries_metrics_by_artifact` | (artifact, date, interval, metric) | Drill into individual repos or onchain artifacts |
+| `key_metrics_by_artifact` | (artifact, metric) | Snapshot totals per individual artifact |
+| `timeseries_metrics_by_pod` | (pod, date, interval, metric) | Metrics for FOC/LDO/Web2 pods over time |
+| `key_metrics_by_pod` | (pod, metric) | Snapshot totals per pod (aggregated across member projects) |
+| `timeseries_metrics_by_program` | (program, date, interval, metric) | Funding programs compared over time |
+| `key_metrics_by_program` | (program, metric) | Snapshot totals per funding program |
+| `timeseries_metrics_by_network` | (date, interval, metric) | Network-wide Filecoin health trends |
+| `key_metrics_by_network` | metric | Latest network-level snapshots |
+
+### Discovering metrics
+
+Query the catalog rather than hardcoding metric names:
 
 ```sql
-SELECT
-  metric_name,
-  metric_display_name,
-  metric_units,
-  metric_description,
-  metric_category
+SELECT metric_name, metric_display_name, metric_units, metric_description, metric_category
 FROM filecoin.filpgf_public.metric_catalog
 ORDER BY metric_category, metric_name
 ```
 
-Metric categories include: `github`, `client_onchain`, `sp_onchain`, `funding`, `downstream`, `network`, `filecoin_pay`, `warm_storage`, `datacap`.
+Metric categories: `github`, `client_onchain`, `sp_onchain`, `funding`, `downstream`, `network`, `filecoin_pay`, `warm_storage`, `datacap`.
 
-To see what snapshot/lifetime metrics exist for a specific project:
+Naming conventions:
+- `key_metrics_by_project`: snapshot metrics use `latest_` prefix (eg `latest_commits`, `latest_active_developers_28d`) or `total_` prefix (eg `total_funding_usd`, `total_sp_onboarded_tibs`)
+- `timeseries_metrics_by_project`: bare names without prefix (eg `commits`, `active_developers_28d`)
+- Dependency survey scores range from 0 (no dependency) to 5 (critical dependency) per pair
 
-```sql
-SELECT metric_name, amount, metric_units
-FROM filecoin.filpgf_public.key_metrics_by_project
-WHERE oso_project_slug = 'lighthouse'
-ORDER BY metric_name
-```
+### Querying patterns
 
-**Note:** Snapshot metrics in `key_metrics_by_project` are prefixed with `latest_` (eg `latest_commits`, `latest_active_developers_28d`) or `total_` (eg `total_funding_usd`, `total_sp_onboarded_tibs`). Timeseries metrics in `timeseries_metrics_by_project` use bare names (eg `commits`, `active_developers_28d`). The dependency survey assigns importance scores from 0 (no dependency) to 5 (critical dependency) per pair.
-
----
-
-## Key tables (mart layer)
-
-All tables below are in the `filecoin.filpgf_public` schema. The universal join key is `oso_project_slug`, which comes from [oss-directory](https://github.com/opensource-observer/oss-directory/tree/main/data/projects) — each project's YAML filename (minus `.yaml`) is its slug.
-
-| Table | Grain | Use when you want to... |
-|-------|-------|------------------------|
-| `projects` | project | List tracked projects, get display names and metadata |
-| `artifacts_by_project` | (project, artifact) | See repos, onchain client IDs, and grant applications per project |
-| `projects_to_projects` | (project, source, name) | Cross-system identity bridges (OSSD ↔ Karma ↔ Drips ↔ Data Portal) |
-| `metric_catalog` | metric | Look up metric definitions, units, and categories |
-| `timeseries_metrics_by_project` | (project, date, interval, metric) | Trend any metric over time for a project |
-| `key_metrics_by_project` | (project, metric) | Get latest snapshot + lifetime totals per project |
-| `timeseries_metrics_by_artifact` | (artifact, date, interval, metric) | Drill down to individual repos or onchain artifacts |
-| `timeseries_metrics_by_program` | (program, date, interval, metric) | Compare funding programs over time |
-| `key_metrics_by_program` | (program, metric) | Snapshot totals per funding program |
-| `timeseries_metrics_by_network` | (date, interval, metric) | Network-wide Filecoin health trends |
-| `key_metrics_by_network` | metric | Latest network-level snapshots |
-| `key_metrics_by_artifact` | (artifact, metric) | Drill down to individual repos or onchain artifacts |
-
----
-
-## Key workflow: Karma milestones → project metrics
-
-A common workflow is checking a project's Karma milestones against its actual performance data. The queries below use OSO warehouse tables, which are refreshed on a schedule. For real-time milestone status, use the [Karma GAP API](karma-api.md) directly or run `fetch_karma.py`.
-
-**Step 1: Find a project's Karma profile via the bridge table**
-
-The bridge table maps `oso_project_slug` to `karma_slug` and `karma_title`:
+List all tracked projects:
 
 ```sql
-SELECT
-  k.karma_slug,
-  k.karma_title,
-  k.oso_project_slug
-FROM filecoin.entities.bridge_karma_to_oso AS k
-WHERE k.oso_project_slug = 'secured-finance'
-```
-
-**Step 2: Get milestones using the `karma_slug` from step 1**
-
-```sql
-SELECT
-  m.project_title,
-  m.milestone_title,
-  m.current_status,
-  m.ends_at,
-  m.status_updated_at
-FROM filecoin.karma_milestones.milestones AS m
-WHERE m.karma_slug = 'secured-finance'  -- use karma_slug from step 1
-ORDER BY m.ends_at
-```
-
-**Step 3: Pull actual metrics to compare against milestones**
-
-Snapshot metrics in `key_metrics_by_project` use `latest_` and `total_` prefixes:
-
-```sql
-SELECT
-  metric_name,
-  amount,
-  metric_units
-FROM filecoin.filpgf_public.key_metrics_by_project
-WHERE oso_project_slug = 'secured-finance'
-  AND metric_name IN (
-    'total_funding_usd',
-    'total_funding_fil',
-    'latest_active_developers_28d',
-    'total_sp_onboarded_tibs',
-    'total_sp_block_rewards_usd',
-    'latest_commits'
-  )
-```
-
-**Step 4: Show the trend**
-
-Timeseries metrics use bare names (no `latest_`/`total_` prefix):
-
-```sql
-SELECT
-  sample_date,
-  metric_name,
-  amount
-FROM filecoin.filpgf_public.timeseries_metrics_by_project
-WHERE oso_project_slug = 'secured-finance'
-  AND metric_name IN ('commits', 'active_developers_28d', 'sp_onboarded_data_tibs')
-  AND time_interval = 'monthly'
-ORDER BY sample_date
-```
-
----
-
-## Reference: full table inventory
-
-Most analysis uses the mart layer above. The sections below document the full DAG for when you need to go deeper — custom joins, raw data, or entity resolution logic.
-
-### Upstream data sources
-
-#### Ingested datasets (`filecoin.data_portal.*`)
-
-Raw Filecoin Data Portal tables — snapshot and daily metrics from the network.
-
-| Table | Rows | Description |
-|-------|------|-------------|
-| `filecoin.data_portal.clients` | ~5k | Client snapshot stats (datacap, deals, providers) |
-| `filecoin.data_portal.storage_providers` | ~7.9k | SP snapshot stats (power, sectors, balance) |
-| `filecoin.data_portal.daily_clients_metrics` | ~3.2M | Daily client-level metrics (market deals only) |
-| `filecoin.data_portal.daily_network_metrics` | ~2k | Daily network-wide metrics (126 columns) |
-| `filecoin.data_portal.daily_filecoin_pay_operators_metrics` | varies | Daily Filecoin Pay operator metrics |
-| `filecoin.data_portal.filecoin_pay_rails` | varies | Filecoin Pay payment rails |
-| `filecoin.data_portal.pdp_service_providers` | varies | PDP (warm storage) service providers |
-| `filecoin.data_portal.warm_storage_datasets` | varies | Warm storage dataset activity |
-
-#### Ingested datasets (`filecoin.karma.*`, `filecoin.datacapstats.*`)
-
-Karma tables are refreshed by scheduled OSO ingestion jobs. For real-time data, query the [Karma GAP API](karma-api.md) directly.
-
-| Table | Description |
-|-------|-------------|
-| `filecoin.karma.registry` | Karma ProPGF project registry (~34 projects, links, metadata) |
-| `filecoin.karma_milestones.milestones` | ProPGF grant milestones from Karma GAP API |
-| `filecoin.datacapstats.verified_clients` | DataCapStats verified client records |
-| `filecoin.datacapstats.verifiers` | DataCapStats allocator/verifier records |
-| `filecoin.datacapstats.filplus_stats` | Network-level FilPlus statistics |
-
-#### Google Sheets connections (`filecoin.gsheets.*`)
-
-| Table | Description |
-|-------|-------------|
-| `filecoin.gsheets.onchain_artifacts` | Curated onchain artifact registry (client IDs, SP IDs, allocator IDs, wallets) |
-| `filecoin.gsheets.public_grants_registry` | Public grants: ProPGF, Impact Grants, Hackathons (~132 rows) |
-| `filecoin.gsheets.private_grants_registry_consolidated` | Private grants registry |
-
-#### Static models
-
-| Table | Description |
-|-------|-------------|
-| `filecoin.token_prices.token_prices` | Daily FIL/USD prices (Yahoo Finance + CoinGecko) |
-| `filecoin.attribution_registry.artifact_registry` | Onchain artifact→entity mapping for onramp attribution |
-| `filecoin.attribution_registry.client_sp_mapping` | Client→SP mappings from DataCapStats |
-| `filecoin.onramp_dependency_scores.survey_submissions` | Dependency survey responses (0-5 importance scores from onramp teams) |
-
----
-
-### Staging layer
-
-Materialized, filtered, and cast views of the raw data. Useful when you need more granularity than the marts.
-
-#### `filecoin.staging_oso.*` (OSO public data, scoped to Filecoin)
-
-| Table | Description |
-|-------|-------------|
-| `staging__oso__projects_by_collection` | Root of DAG — projects in `filecoin-*` collections |
-| `staging__oso__projects` | Filecoin project metadata |
-| `staging__oso__artifacts_by_project` | All artifact types per project |
-| `staging__oso__repositories` | GitHub repo metadata (stars, forks, language, license) |
-| `staging__oso__github_events` | GitHub events for tracked repos, >= 2024-01-01 |
-
-#### `filecoin.staging_external.*` (external sources)
-
-| Table | Description |
-|-------|-------------|
-| `staging__data_portal__allocators` | Allocator→client mapping with metadata |
-| `staging__data_portal__clients` | Client snapshot stats |
-| `staging__data_portal__client_providers` | Client→SP mapping |
-| `staging__data_portal__daily_clients` | Deduplicated daily client metrics, >= 2024-01-01 |
-| `staging__data_portal__daily_network` | Daily network-wide metrics, >= 2024-01-01 |
-| `staging__data_portal__daily_sp_metrics` | Deduplicated daily SP metrics (~150 days only) |
-| `staging__data_portal__filecoin_pay_operators` | Filecoin Pay operator staging |
-| `staging__data_portal__filecoin_pay_rails` | Filecoin Pay rails staging |
-| `staging__data_portal__warm_storage` | Warm storage staging |
-| `staging__drips__rpgf_applications` | Drips RetroPGF records with JSON extraction |
-| `staging__drips__rpgf_support_items` | Per-support-item funding: wei→FIL conversion |
-| `staging__gsheets__onchain_artifacts` | Curated onchain artifact registry |
-| `staging__gsheets__public_grants` | Cleaned public grants with program mapping |
-| `staging__gsheets__private_grants` | Cleaned private grants |
-| `staging__karma__registry` | Karma ProPGF projects with flattened links |
-| `staging__survey__submissions` | Dependency survey responses |
-| `staging__survey__progress` | Survey completion progress |
-
----
-
-### Derived layers
-
-#### `filecoin.entities.*` (entity resolution)
-
-| Table | Description |
-|-------|-------------|
-| `registry_ossd` | ~337 OSSD projects in Filecoin collections |
-| `registry_propgf` | ~34 Karma ProPGF projects |
-| `registry_retropgf` | ~111 Drips RetroPGF applications with earned amounts |
-| `registry_data_portal` | ~523 active Data Portal entities |
-| `bridge_karma_to_oso` | Karma slug → OSSD project mapping |
-| `bridge_drips_to_oso` | Drips repo → OSSD mapping (override for renames) |
-| `bridge_data_portal_to_oso` | Data Portal entity → OSSD slug mapping |
-| `projects_canonical` | Unified project list across all registries |
-| `projects_bridged` | Cross-system identity mappings |
-| `artifacts_github_repos` | GitHub repos per project |
-| `artifacts_onchain` | Onchain artifacts (client IDs, SP IDs, allocator IDs, wallets) |
-| `artifacts_grant_applications` | Grant applications per (project, program) |
-| `dependency_classification` | Project type: pod, sp_operator, onramp, infrastructure, ecosystem_support |
-| `dependency_matrix` | Weighted dependency edges from survey |
-
-#### `filecoin.events.*`
-
-| Table | Description |
-|-------|-------------|
-| `events_github` | GitHub events for tracked repos |
-| `events_onchain` | Daily client metrics joined to artifacts for entity resolution |
-| `events_public_funding` | RetroPGF + ProPGF + Impact Grants + Hackathons |
-| `events_private_funding` | Private grant events |
-
-#### `filecoin.metrics.*`
-
-| Table | Grain | Description |
-|-------|-------|-------------|
-| `metrics_github` | (project, date) | Daily event counts + 28d rolling unique actors |
-| `metrics_onchain` | (entity/project, date) | Client-side + SP-side attributed metrics |
-| `metrics_downstream` | (project, date) | Weighted downstream impact via dependency matrix |
-| `metrics_public_funding` | (project, date, program) | Daily funding amounts per program |
-| `metrics_private_funding` | (project, month) | Monthly boolean for active private grants |
-| `metrics_network_level` | (date) | Network-wide: power, gas, revenue, token economics |
-| `metrics_filecoin_pay` | (date, entity, metric) | Filecoin Pay ARR and warm storage per operator |
-| `metrics_warm_storage` | (project, date) | Warm storage activity per PDP provider |
-| `metrics_datacap` | (entity) | Data Portal snapshot stats: onramp activity, allocator datacap |
-
-#### `filecoin.roi.*`
-
-| Table | Description |
-|-------|-------------|
-| `all_funding_events` | Unified funding events, USD-normalized via token_prices |
-| `roi_project_summary` | Per-project: total funding (FIL + USD) + impact metrics snapshot |
-
----
-
-## Starter queries
-
-**List all tracked projects:**
-
-```sql
-SELECT
-  oso_project_slug,
-  display_name
+SELECT oso_project_slug, display_name
 FROM filecoin.filpgf_public.projects
 ORDER BY display_name
 ```
 
-**Top funded projects (lifetime totals):**
+Top funded projects (lifetime totals):
 
 ```sql
 SELECT
@@ -414,13 +158,10 @@ ORDER BY total_usd DESC NULLS LAST
 LIMIT 30
 ```
 
-**Monthly developer activity across all Filecoin projects:**
+Monthly developer activity across all projects:
 
 ```sql
-SELECT
-  sample_date,
-  metric_name,
-  SUM(amount) AS total
+SELECT sample_date, metric_name, SUM(amount) AS total
 FROM filecoin.filpgf_public.timeseries_metrics_by_project
 WHERE metric_name IN ('commits', 'active_developers_28d')
   AND time_interval = 'monthly'
@@ -428,13 +169,10 @@ GROUP BY sample_date, metric_name
 ORDER BY sample_date
 ```
 
-**Funding by program over time:**
+Funding by program over time:
 
 ```sql
-SELECT
-  sample_date,
-  metric_name,
-  SUM(amount) AS total
+SELECT sample_date, metric_name, SUM(amount) AS total
 FROM filecoin.filpgf_public.timeseries_metrics_by_program
 WHERE metric_name IN ('propgf_amount_usd', 'retropgf_amount_fil', 'impact_grants_amount_fil')
   AND time_interval = 'monthly'
@@ -442,26 +180,21 @@ GROUP BY sample_date, metric_name
 ORDER BY sample_date
 ```
 
-**Network health (last 30 days):**
+Network health (last 30 days):
 
 ```sql
-SELECT
-  sample_date,
-  metric_name,
-  amount
+SELECT sample_date, metric_name, amount
 FROM filecoin.filpgf_public.timeseries_metrics_by_network
 WHERE metric_name IN (
-  'network_raw_power_pibs',
-  'network_daily_onboarding_tibs',
-  'fil_price_usd',
-  'network_block_rewards_fil'
+  'network_raw_power_pibs', 'network_daily_onboarding_tibs',
+  'fil_price_usd', 'network_block_rewards_fil'
 )
 AND time_interval = 'daily'
 AND sample_date >= CURRENT_DATE - INTERVAL '30' DAY
 ORDER BY sample_date, metric_name
 ```
 
-**Project ROI: funding vs impact:**
+Project ROI — funding vs impact:
 
 ```sql
 SELECT
@@ -479,31 +212,235 @@ HAVING MAX(CASE WHEN k.metric_name = 'total_funding_usd' THEN k.amount END) > 0
 ORDER BY funding_usd DESC
 ```
 
----
-
-## Important notes
-
-- **Timeseries data starts from 2024-01-01.** Lifetime totals in `key_metrics_by_project` reflect post-2024 activity only.
-- **DDO onramps (Ramo, Titan) bypass the deal pipeline.** Their `client_*` metrics are NULL — only `sp_*` metrics capture their activity.
-- **Amounts are in native currency** (FIL or USD depending on the metric). Check `metric_units` in the catalog.
-- **Private funding is boolean only.** The `received_private_grant` metric shows whether a project had an active private grant (1/0), but amounts are not exposed publicly.
-- **All `filecoin.*` tables are accessible** with a Filecoin-scoped API key — including staging, entities, metrics, and raw ingested data. Start with `filpgf_public` for most analysis; go deeper when you need custom joins.
-
----
-
-## Joining with OSO public data
-
-Filecoin projects are tracked in [oss-directory](https://github.com/opensource-observer/oss-directory). You can join Filecoin data with the public `oso.*` namespace using `oso_project_slug`:
+Pod-level metrics (FOC, LDO, Web2):
 
 ```sql
-SELECT
-  fp.oso_project_slug,
-  fp.display_name,
-  op.description
+SELECT pod_slug, metric_name, member_count, sum_amount, avg_amount, metric_units
+FROM filecoin.filpgf_public.key_metrics_by_pod
+ORDER BY pod_slug, metric_name
+```
+
+### Karma milestones workflow
+
+To check a project's milestones against its metrics:
+
+1. Find cross-system identities (includes Karma slug) via the mart layer:
+
+```sql
+SELECT source, source_project_slug, source_project_name
+FROM filecoin.filpgf_public.projects_to_projects
+WHERE oso_project_slug = 'secured-finance'
+```
+
+2. For real-time milestone data, use the Karma GAP API directly — see [guides/karma-api.md](guides/karma-api.md). No API key required. For warehouse-based milestone queries, see [FILECOIN_ORG: Karma milestones](#filecoin_org-karma-milestones-workflow) below.
+
+3. Pull snapshot metrics from the mart layer:
+
+```sql
+SELECT metric_name, amount, metric_units
+FROM filecoin.filpgf_public.key_metrics_by_project
+WHERE oso_project_slug = 'secured-finance'
+  AND metric_name IN (
+    'total_funding_usd', 'total_funding_fil',
+    'latest_active_developers_28d', 'total_sp_onboarded_tibs',
+    'total_sp_block_rewards_usd', 'latest_commits'
+  )
+```
+
+4. Show the trend (timeseries metrics use bare names, no prefix):
+
+```sql
+SELECT sample_date, metric_name, amount
+FROM filecoin.filpgf_public.timeseries_metrics_by_project
+WHERE oso_project_slug = 'secured-finance'
+  AND metric_name IN ('commits', 'active_developers_28d', 'sp_onboarded_data_tibs')
+  AND time_interval = 'monthly'
+ORDER BY sample_date
+```
+
+### Joining with OSO public data
+
+Join Filecoin data with the `oso.*` namespace using `oso_project_slug`:
+
+```sql
+SELECT fp.oso_project_slug, fp.display_name, op.description
 FROM filecoin.filpgf_public.projects AS fp
 INNER JOIN oso.projects_v1 AS op
   ON fp.oso_project_slug = op.project_name
   AND op.project_source = 'OSS_DIRECTORY'
 ```
 
-This gives you access to the full OSO metrics ecosystem (code metrics, onchain activity, funding from other sources) alongside the Filecoin-specific data.
+### Caveats
+
+- Timeseries data starts from 2024-01-01. Lifetime totals in `key_metrics_by_project` reflect post-2024 activity only.
+- DDO onramps (Ramo, Titan) bypass the deal pipeline. Their `client_*` metrics are NULL — only `sp_*` metrics capture their activity.
+- Amounts are in native currency (FIL or USD depending on the metric). Check `metric_units` in the catalog.
+- Private funding is boolean only. The `received_private_grant` metric shows 1/0, not amounts.
+- Pod metrics aggregate across member projects — they reflect the pod's collective footprint, not individual project metrics.
+
+---
+
+## FILECOIN_ORG tables
+
+Everything below requires FILECOIN_ORG access (full `filecoin.*` namespace). Do not use these tables unless the user has confirmed org-level access or explicitly requested tables from these schemas.
+
+### FILECOIN_ORG: Karma milestones workflow
+
+For milestone data via the warehouse (rather than the Karma GAP API):
+
+Step 1 — find a project's Karma profile:
+
+```sql
+SELECT k.karma_slug, k.karma_title, k.oso_project_slug
+FROM filecoin.entities.bridge_karma_to_oso AS k
+WHERE k.oso_project_slug = 'secured-finance'
+```
+
+Step 2 — get milestones:
+
+```sql
+SELECT m.project_title, m.milestone_title, m.current_status, m.ends_at, m.status_updated_at
+FROM filecoin.karma_milestones.milestones AS m
+WHERE m.karma_slug = 'secured-finance'
+ORDER BY m.ends_at
+```
+
+Step 3 — check pod membership (for pod grants):
+
+```sql
+SELECT pod_slug, pod_display_name, member_slug, member_role, criticality
+FROM filecoin.staging_external.staging__gsheets__pod_membership
+WHERE pod_slug IN ('foc', 'ldo', 'web2')
+ORDER BY pod_slug, criticality, member_slug
+```
+
+Pod grants map Karma slugs to pod slugs: `foc-filecoin-onachain-cloud` -> `foc`, `large-data-onboarding-pod-ldo-pod` -> `ldo`, `web2-object-storage-pod` -> `web2`.
+
+### FILECOIN_ORG: Full table inventory
+
+#### Ingested datasets (filecoin.data_portal.*)
+
+Raw Filecoin Data Portal tables — snapshot and daily metrics from the network.
+
+| Table | Rows | Description |
+|-------|------|-------------|
+| `filecoin.data_portal.clients` | ~5k | Client snapshot stats (datacap, deals, providers) |
+| `filecoin.data_portal.storage_providers` | ~7.9k | SP snapshot stats (power, sectors, balance) |
+| `filecoin.data_portal.daily_clients_metrics` | ~3.2M | Daily client-level metrics (market deals only) |
+| `filecoin.data_portal.daily_network_metrics` | ~2k | Daily network-wide metrics (126 columns) |
+| `filecoin.data_portal.daily_filecoin_pay_operators_metrics` | varies | Daily Filecoin Pay operator metrics |
+| `filecoin.data_portal.filecoin_pay_rails` | varies | Filecoin Pay payment rails |
+| `filecoin.data_portal.pdp_service_providers` | varies | PDP (warm storage) service providers |
+| `filecoin.data_portal.warm_storage_datasets` | varies | Warm storage dataset activity |
+
+#### Ingested datasets (filecoin.karma.*, filecoin.datacapstats.*)
+
+Karma tables are refreshed by scheduled OSO ingestion jobs. For real-time data, use the Karma GAP API.
+
+| Table | Description |
+|-------|-------------|
+| `filecoin.karma.registry` | Karma ProPGF project registry (~34 projects, links, metadata) |
+| `filecoin.karma_milestones.milestones` | ProPGF grant milestones from Karma GAP API |
+| `filecoin.datacapstats.verified_clients` | DataCapStats verified client records |
+| `filecoin.datacapstats.verifiers` | DataCapStats allocator/verifier records |
+| `filecoin.datacapstats.filplus_stats` | Network-level FilPlus statistics |
+
+#### Google Sheets connections (filecoin.gsheets.*)
+
+| Table | Description |
+|-------|-------------|
+| `filecoin.gsheets.onchain_artifacts` | Curated onchain artifact registry (client IDs, SP IDs, allocator IDs, wallets) |
+| `filecoin.gsheets.public_grants_registry` | Public grants: ProPGF, Impact Grants, Hackathons (~132 rows) |
+| `filecoin.gsheets.private_grants_registry_consolidated` | Private grants registry |
+
+#### Static models
+
+| Table | Description |
+|-------|-------------|
+| `filecoin.token_prices.token_prices` | Daily FIL/USD prices (Yahoo Finance + CoinGecko) |
+| `filecoin.attribution_registry.artifact_registry` | Onchain artifact->entity mapping for onramp attribution |
+| `filecoin.attribution_registry.client_sp_mapping` | Client->SP mappings from DataCapStats |
+| `filecoin.onramp_dependency_scores.survey_submissions` | Dependency survey responses (0-5 importance scores) |
+
+#### Staging: filecoin.staging_oso.* (OSO public data scoped to Filecoin)
+
+| Table | Description |
+|-------|-------------|
+| `staging__oso__projects_by_collection` | Root of DAG — projects in `filecoin-*` collections |
+| `staging__oso__projects` | Filecoin project metadata |
+| `staging__oso__artifacts_by_project` | All artifact types per project |
+| `staging__oso__repositories` | GitHub repo metadata (stars, forks, language, license) |
+| `staging__oso__github_events` | GitHub events for tracked repos, >= 2024-01-01 |
+
+#### Staging: filecoin.staging_external.* (external sources)
+
+| Table | Description |
+|-------|-------------|
+| `staging__data_portal__allocators` | Allocator->client mapping with metadata |
+| `staging__data_portal__clients` | Client snapshot stats |
+| `staging__data_portal__client_providers` | Client->SP mapping |
+| `staging__data_portal__daily_clients` | Deduplicated daily client metrics, >= 2024-01-01 |
+| `staging__data_portal__daily_network` | Daily network-wide metrics, >= 2024-01-01 |
+| `staging__data_portal__daily_sp_metrics` | Deduplicated daily SP metrics (~150 days only) |
+| `staging__data_portal__filecoin_pay_operators` | Filecoin Pay operator staging |
+| `staging__data_portal__filecoin_pay_rails` | Filecoin Pay rails staging |
+| `staging__data_portal__warm_storage` | Warm storage staging |
+| `staging__drips__rpgf_applications` | Drips RetroPGF records with JSON extraction |
+| `staging__drips__rpgf_support_items` | Per-support-item funding: wei->FIL conversion |
+| `staging__gsheets__onchain_artifacts` | Curated onchain artifact registry |
+| `staging__gsheets__pod_membership` | Pod membership roster (FOC, LDO, Web2) |
+| `staging__gsheets__public_grants` | Cleaned public grants with program mapping |
+| `staging__gsheets__private_grants` | Cleaned private grants |
+| `staging__karma__registry` | Karma ProPGF projects with flattened links |
+| `staging__survey__submissions` | Dependency survey responses |
+| `staging__survey__progress` | Survey completion progress |
+| `staging__token_prices__fil_30d_avg` | 30-day rolling average FIL/USD price |
+
+#### Entities: filecoin.entities.* (entity resolution)
+
+| Table | Description |
+|-------|-------------|
+| `registry_ossd` | ~337 OSSD projects in Filecoin collections |
+| `registry_propgf` | ~34 Karma ProPGF projects |
+| `registry_retropgf` | ~111 Drips RetroPGF applications with earned amounts |
+| `registry_data_portal` | ~523 active Data Portal entities |
+| `bridge_karma_to_oso` | Karma slug -> OSSD project mapping |
+| `bridge_drips_to_oso` | Drips repo -> OSSD mapping (override for renames) |
+| `bridge_data_portal_to_oso` | Data Portal entity -> OSSD slug mapping |
+| `projects_canonical` | Unified project list across all registries |
+| `projects_bridged` | Cross-system identity mappings |
+| `artifacts_github_repos` | GitHub repos per project |
+| `artifacts_onchain` | Onchain artifacts (client IDs, SP IDs, allocator IDs, wallets) |
+| `artifacts_grant_applications` | Grant applications per (project, program) |
+| `dependency_classification` | Project type: pod, sp_operator, onramp, infrastructure, ecosystem_support |
+| `dependency_matrix` | Weighted dependency edges from survey |
+
+#### Events: filecoin.events.*
+
+| Table | Description |
+|-------|-------------|
+| `events_github` | GitHub events for tracked repos |
+| `events_onchain` | Daily client metrics joined to artifacts for entity resolution |
+| `events_public_funding` | RetroPGF + ProPGF + Impact Grants + Hackathons |
+| `events_private_funding` | Private grant events |
+
+#### Metrics: filecoin.metrics.*
+
+| Table | Grain | Description |
+|-------|-------|-------------|
+| `metrics_github` | (project, date) | Daily event counts + 28d rolling unique actors |
+| `metrics_onchain` | (entity/project, date) | Client-side + SP-side attributed metrics |
+| `metrics_downstream` | (project, date) | Weighted downstream impact via dependency matrix |
+| `metrics_public_funding` | (project, date, program) | Daily funding amounts per program |
+| `metrics_private_funding` | (project, month) | Monthly boolean for active private grants |
+| `metrics_network_level` | (date) | Network-wide: power, gas, revenue, token economics |
+| `metrics_filecoin_pay` | (date, entity, metric) | Filecoin Pay ARR and warm storage per operator |
+| `metrics_warm_storage` | (project, date) | Warm storage activity per PDP provider |
+| `metrics_datacap` | (entity) | Data Portal snapshot stats: onramp activity, allocator datacap |
+
+#### ROI: filecoin.roi.*
+
+| Table | Description |
+|-------|-------------|
+| `all_funding_events` | Unified funding events, USD-normalized via token_prices |
+| `roi_project_summary` | Per-project: total funding (FIL + USD) + impact metrics snapshot |

--- a/community/filecoin/skills.md
+++ b/community/filecoin/skills.md
@@ -63,8 +63,7 @@ Use Trino SQL:
 FILECOIN layer              Public layer
 ───────────────────             ────────────
 filecoin.data_portal.*          oso.projects_v1
-filecoin.gsheets.*              oso.artifacts_by_project_v1
-filecoin.karma.*                oso.timeseries_metrics_by_project_v0
+filecoin.karma.*                oso.artifacts_by_project_v1
 filecoin.datacapstats.*         oso.int_events__github_unified
 filecoin.token_prices.*         (etc.)
 filecoin.karma_milestones.*
@@ -341,14 +340,6 @@ Karma tables are refreshed by scheduled OSO ingestion jobs. For real-time data, 
 | `filecoin.datacapstats.verified_clients` | DataCapStats verified client records |
 | `filecoin.datacapstats.verifiers` | DataCapStats allocator/verifier records |
 | `filecoin.datacapstats.filplus_stats` | Network-level FilPlus statistics |
-
-#### Google Sheets connections (filecoin.gsheets.*)
-
-| Table | Description |
-|-------|-------------|
-| `filecoin.gsheets.onchain_artifacts` | Curated onchain artifact registry (client IDs, SP IDs, allocator IDs, wallets) |
-| `filecoin.gsheets.public_grants_registry` | Public grants: ProPGF, Impact Grants, Hackathons (~132 rows) |
-| `filecoin.gsheets.private_grants_registry_consolidated` | Private grants registry |
 
 #### Static models
 

--- a/community/filecoin/skills.md
+++ b/community/filecoin/skills.md
@@ -345,7 +345,7 @@ Karma tables are refreshed by scheduled OSO ingestion jobs. For real-time data, 
 
 | Table | Description |
 |-------|-------------|
-| `filecoin.token_prices.token_prices` | Daily FIL/USD prices (Yahoo Finance + CoinGecko) |
+| `filecoin.token_prices.fil_daily_prices` | Daily FIL/USD prices (Yahoo Finance + CoinGecko) |
 | `filecoin.attribution_registry.artifact_registry` | Onchain artifact->entity mapping for onramp attribution |
 | `filecoin.attribution_registry.client_sp_mapping` | Client->SP mappings from DataCapStats |
 | `filecoin.onramp_dependency_scores.survey_submissions` | Dependency survey responses (0-5 importance scores) |

--- a/community/filecoin/skills.md
+++ b/community/filecoin/skills.md
@@ -135,7 +135,7 @@ All tables use `oso_project_slug` as the universal join key. Slugs come from OSS
 |-------|-------|-------------|
 | `projects` | project | Tracked projects with display names and metadata |
 | `artifacts_by_project` | (project, artifact) | Repos, onchain client IDs, and grant applications per project |
-| `projects_to_projects` | (project, source, name) | Cross-system identity bridges: OSSD, Karma, Drips, Data Portal |
+| `projects_to_projects` | (project, registry_source, registry_project_name) | Cross-system identity bridges: OSSD, Karma, Drips, Data Portal |
 | `metric_catalog` | metric | Metric definitions, units, categories, and descriptions |
 | `timeseries_metrics_by_project` | (project, date, interval, metric) | Any metric trended over time for a project |
 | `key_metrics_by_project` | (project, metric) | Latest snapshot + lifetime totals per project |
@@ -153,12 +153,12 @@ All tables use `oso_project_slug` as the universal join key. Slugs come from OSS
 Query the catalog rather than hardcoding metric names:
 
 ```sql
-SELECT metric_name, metric_display_name, metric_units, metric_description, metric_category
+SELECT metric_name, metric_display_name, metric_units, description, metric_event_source
 FROM filecoin.filpgf_public.metric_catalog
-ORDER BY metric_category, metric_name
+ORDER BY metric_event_source, metric_name
 ```
 
-Metric categories: `github`, `client_onchain`, `sp_onchain`, `funding`, `downstream`, `network`, `filecoin_pay`, `warm_storage`, `datacap`.
+Metric event sources: `github`, `client_verified`, `sp_attribution`, `funding_events`, `private_funding`, `program`, `survey_dependency`, `filecoin_network`, `filecoin_pay`, `warm_storage`.
 
 Naming conventions:
 - `key_metrics_by_project`: snapshot metrics use `latest_` prefix (eg `latest_commits`, `latest_active_developers_28d`) or `total_` prefix (eg `total_funding_usd`, `total_sp_onboarded_tibs`)
@@ -262,7 +262,7 @@ To check a project's milestones against its metrics:
 1. Find cross-system identities (includes Karma slug) via the mart layer:
 
 ```sql
-SELECT source, source_project_slug, source_project_name
+SELECT oso_project_slug, registry_source, registry_project_name
 FROM filecoin.filpgf_public.projects_to_projects
 WHERE oso_project_slug = 'secured-finance'
 ```

--- a/community/filecoin/skills.md
+++ b/community/filecoin/skills.md
@@ -12,10 +12,10 @@ COMMUNITY (any OSO user who has subscribed to the filecoin.filpgf_public.* datas
   oso.*                        — public OSO data (projects, metrics, events)
 
 FILECOIN (any OSO user who is a member of the `filecoin` org space on OSO):
-  filecoin.*                   — all tables: staging, entities, events, metrics, ROI, raw ingested data
+  filecoin.*                   — all tables: staging, entities, events, metrics, and raw ingested data
 ```
 
-When generating queries, use `filecoin.filpgf_public.*` and `oso.*` tables. Only use deeper layers (staging, entities, events, metrics, roi) if the user has FILECOIN access and the mart layer cannot answer the question.
+When generating queries, use `filecoin.filpgf_public.*` and `oso.*` tables. Only use deeper layers (staging, entities, events, metrics) if the user has FILECOIN access and the mart layer cannot answer the question.
 
 ## Resources
 
@@ -80,7 +80,7 @@ filecoin.staging_external.*     filecoin.staging_oso.*
                          |
                   filecoin.metrics.*
                          |
-             filecoin.filpgf_public.*  <-- filecoin.roi.*
+             filecoin.filpgf_public.*
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
              COMMUNITY layer — default for all queries
 ```
@@ -191,7 +191,7 @@ AND sample_date >= CURRENT_DATE - INTERVAL '30' DAY
 ORDER BY sample_date, metric_name
 ```
 
-Project ROI — funding vs impact:
+Funding vs impact by project:
 
 ```sql
 SELECT
@@ -229,7 +229,7 @@ FROM filecoin.filpgf_public.projects_to_projects
 WHERE oso_project_slug = 'secured-finance'
 ```
 
-2. For real-time milestone data, use the Karma GAP API directly — see [guides/karma-api.md](guides/karma-api.md). No API key required. For warehouse-based milestone queries, see [FILECOIN: Karma milestones](#filecoin-karma-milestones-workflow) below.
+2. Get milestone data from the Karma GAP API — see [guides/karma-api.md](guides/karma-api.md). No API key required, works for all users. FILECOIN tier users can also query milestones from the warehouse — see [FILECOIN: Karma milestones](#filecoin-karma-milestones-workflow) below.
 
 3. Pull snapshot metrics from the mart layer:
 
@@ -434,10 +434,3 @@ Karma tables are refreshed by scheduled OSO ingestion jobs. For real-time data, 
 | `metrics_filecoin_pay` | (date, entity, metric) | Filecoin Pay ARR and warm storage per operator |
 | `metrics_warm_storage` | (project, date) | Warm storage activity per PDP provider |
 | `metrics_datacap` | (entity) | Data Portal snapshot stats: onramp activity, allocator datacap |
-
-#### ROI: filecoin.roi.*
-
-| Table | Description |
-|-------|-------------|
-| `all_funding_events` | Unified funding events, USD-normalized via token_prices |
-| `roi_project_summary` | Per-project: total funding (FIL + USD) + impact metrics snapshot |


### PR DESCRIPTION
## Summary

- Adds explicit access tier labels (COMMUNITY / FILECOIN_ORG / OSO_INTERNAL) to `skills.md` so agent consumers know which tables to use by default
- Restructures for agent-first consumption: machine-parseable tier definitions, behavioral routing instructions, no emoji decorations
- Adds missing `filpgf_public` pod tables (`key_metrics_by_pod`, `timeseries_metrics_by_pod`) to the mart reference
- Moves internal-only tables (staging, entities, events, metrics, ROI) and Karma milestone warehouse workflow below a clear FILECOIN_ORG gate
- Adds newly created staging tables (`pod_membership`, `fil_30d_avg`) to the inventory
- Default behavior: agents use `filpgf_public.*` + `oso.*` unless user explicitly confirms org access

Closes OSO-2729

## Test plan

- [x] Verify all `filpgf_public` table names match deployed models
- [x] Confirm starter queries execute without errors
- [x] Test with an agent (OSO Chat or Claude) to verify tier routing works as expected
- [x] Check that `propgf-monitoring.md` and `execute_oso_query.py` still make sense alongside the new structure (they reference FILECOIN_ORG tables — may need follow-up updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)